### PR TITLE
[!!!][FEATURE] Added TYPO3 12.4 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        typo3: [ ^11.5]
-        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        typo3: [ ^12.4]
+        php: [ '8.1', '8.2', '8.3' ]
 
     steps:
       - name: Start database server
@@ -45,19 +45,19 @@ jobs:
         run: find . -name \*.php ! -path "./.Build/*" ! -path "./scripts/*" ! -path "./typo3_src/*" | parallel --gnu php -d display_errors=stderr -l {} > /dev/null \;
 
       - name: Unit Tests without coverage
-        if: matrix.typo3 != '^11.5' || matrix.php != '8.3'
+        if: matrix.typo3 != '^12.4' || matrix.php != '8.3'
         run: |
           export "UNIT_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml
           .Build/bin/phpunit --colors -c $UNIT_XML Tests/Unit
 
       - name: Unit Tests with coverage
-        if: matrix.typo3 == '^11.5' && matrix.php == '8.3'
+        if: matrix.typo3 == '^12.4' && matrix.php == '8.3'
         run: |
-          export "UNIT_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests-v10.xml 
+          export "UNIT_XML"=.Build/vendor/typo3/testing-framework/Resources/Core/Build/UnitTests-v10.xml
           .Build/bin/phpunit --coverage-filter Classes --coverage-clover=unittest-coverage.clover --colors -c $UNIT_XML Tests/Unit/
 
       - name: Upload functional coverage results to Scrutinizer
         uses: sudo-bot/action-scrutinizer@latest
-        if: matrix.typo3 == '^11.5' && matrix.php == '8.3'
+        if: matrix.typo3 == '^12.4' && matrix.php == '8.3'
         with:
           cli-args: "--format=php-clover functional-coverage.clover --revision=${{ github.event.pull_request.head.sha || github.sha }}"

--- a/Classes/Typo3/RefIndex.php
+++ b/Classes/Typo3/RefIndex.php
@@ -26,8 +26,6 @@ namespace Aoe\UpdateRefindex\Typo3;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-use Doctrine\DBAL\FetchMode;
-use PDO;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -111,7 +109,7 @@ class RefIndex
                         $queryBuilder->createNamedParameter($this->getExistingTables(), Connection::PARAM_STR_ARRAY)
                     )
             );
-        $queryBuilder->execute();
+        $queryBuilder->executeStatement();
     }
 
     /**
@@ -125,8 +123,8 @@ class RefIndex
         $allRecs = $queryBuilder
             ->select('uid')
             ->from($tableName)
-            ->execute()
-            ->fetchAll(FetchMode::ASSOCIATIVE);
+            ->executeQuery()
+            ->fetchAllAssociative();
 
         // Update refindex table for all records in table
         foreach ($allRecs as $recdat) {
@@ -146,7 +144,7 @@ class RefIndex
                         $queryBuilder->expr()
                             ->eq(
                                 'tablename',
-                                $queryBuilder->createNamedParameter($tableName, PDO::PARAM_STR)
+                                $queryBuilder->createNamedParameter($tableName)
                             )
                     )
                     ->andWhere(
@@ -156,7 +154,7 @@ class RefIndex
                                 $queryBuilder->createNamedParameter($recUidChunk, Connection::PARAM_INT_ARRAY)
                             )
                     );
-                $queryBuilder->execute();
+                $queryBuilder->executeStatement();
             }
         }
     }
@@ -179,14 +177,14 @@ class RefIndex
             ->from('sys_refindex')
             ->where(
                 $queryBuilder->expr()
-                    ->eq('tablename', $queryBuilder->createNamedParameter($tableName, PDO::PARAM_STR))
+                    ->eq('tablename', $queryBuilder->createNamedParameter($tableName))
             )
             ->andWhere($queryBuilder->expr()->notIn('recuid', $subQueryBuilder->getSQL()))
             ->groupBy('recuid');
 
         $allRecs = $queryBuilder
-            ->execute()
-            ->fetchAll(FetchMode::ASSOCIATIVE);
+            ->executeQuery()
+            ->fetchAllAssociative();
 
         $recUidList = [0];
         foreach ($allRecs as $recdat) {

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,11 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "typo3/cms-core": "^11.5",
+        "typo3/cms-core": "^12.4",
         "typo3/cms-scheduler": "*"
     },
     "require-dev": {
-        "typo3/testing-framework": "^7.0.4",
+        "typo3/testing-framework": "^8.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpcov": "*",
         "phpcompatibility/php-compatibility": "^9.3",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -25,10 +25,10 @@ $EM_CONF[$_EXTKEY] = [
     'modify_tables' => '',
     'clearCacheOnLoad' => 1,
     'lockType' => '',
-    'version' => '11.0.0',
+    'version' => '12.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-11.5.99',
+            'typo3' => '12.4.0-12.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,14 +1,13 @@
 <?php
-if (!defined('TYPO3_MODE')) {
-	die ('Access denied.');
-}
 
-if (TYPO3_MODE == 'BE') {
-	// register scheduler-task to update refindex of TYPO3
-	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][\Aoe\UpdateRefindex\Scheduler\UpdateRefIndexTask::class] = [
-		'extension'        => 'update_refindex',
-		'title'            => 'LLL:EXT:update_refindex/Resources/Private/Language/locallang.xlf:scheduler_task_updateRefindex.name',
-		'description'      => 'LLL:EXT:update_refindex/Resources/Private/Language/locallang.xlf:scheduler_task_updateRefindex.description',
-		'additionalFields' => \Aoe\UpdateRefindex\Scheduler\UpdateRefIndexAdditionalFields::class,
-    ];
-}
+defined('TYPO3') or die();
+
+use Aoe\UpdateRefindex\Scheduler\UpdateRefIndexAdditionalFields;
+use Aoe\UpdateRefindex\Scheduler\UpdateRefIndexTask;
+
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][UpdateRefIndexTask::class] = [
+    'extension' => 'update_refindex',
+    'title' => 'LLL:EXT:update_refindex/Resources/Private/Language/locallang.xlf:scheduler_task_updateRefindex.name',
+    'description' => 'LLL:EXT:update_refindex/Resources/Private/Language/locallang.xlf:scheduler_task_updateRefindex.description',
+    'additionalFields' => UpdateRefIndexAdditionalFields::class,
+];


### PR DESCRIPTION
This change basically just adds TYPO3 v12 compatibility. 

I did not migrate the tests, since this is a bigger task, as phpunit prophecy is deprecated and nearly all tests are relying on that package. See this https://forge.typo3.org/issues/98557 forge ticket for examples on how to migarte the tests. Maybe switch to functional tests here and use `assertCSVDataSet` compare, if expected tables have been updated by the reference index task.